### PR TITLE
[FIX] iwp_website: Signup for company

### DIFF
--- a/iwp_website/controllers/auth_signup_investor.py
+++ b/iwp_website/controllers/auth_signup_investor.py
@@ -121,6 +121,7 @@ class AuthSignupInvestor(AuthSignupHome):
                 }
                 rep_values.update({
                     'type': 'representative',
+                    'representative': True,
                     'parent_id': n_user.partner_id.id,
                     'lang': n_user.lang,
                 })


### PR DESCRIPTION
Normally this will fix bug about legal representative not set. But I think I should refactor the signup to match the same way easy_my_coop create legal representative.