### PR TITLE
[FIX] iwp_website: Amount of loan wallet

### DIFF
--- a/iwp_website/controllers/investor_portal.py
+++ b/iwp_website/controllers/investor_portal.py
@@ -309,7 +309,16 @@ class InvestorPortal(CustomerPortal):
         )
         loanline_amount = sum(
             r.amount
-            for r in loanline_mgr.sudo().search(self.loan_issue_line_domain)
+            for r in (
+                loanline_mgr.sudo()
+                .search(self.loan_issue_line_domain)
+                .filtered(
+                    lambda r: (
+                        r.state == "paid" or r.state == "waiting"
+                        or r.state == "subscribed"
+                    )
+                )
+            )
         )
         # Subscription request
         register_mgr = request.env['subscription.register']


### PR DESCRIPTION
Total amount of loan wallet now takes only count of "paid", "subscribed"
and "waiting" loan issue line.