### PR TITLE
[12.0] [FIX] get confirm paid email template

### DIFF
--- a/investor_wallet_platform_base/models/mail_template.py
+++ b/investor_wallet_platform_base/models/mail_template.py
@@ -38,7 +38,7 @@ class MailTemplate(models.Model):
         template_obj = self.env['mail.template']
         mail_template = template_obj.search([
                             ('template_key', '=', mail_template_key),
-                            ('structure', '=', structure.id)])
+                            ('structure', '=', structure.id)], limit=1)
 
         if not mail_template:
             raise ValidationError(

--- a/investor_wallet_platform_base/views/mail_template.xml
+++ b/investor_wallet_platform_base/views/mail_template.xml
@@ -31,4 +31,15 @@
         <field name="domain">[('iwp','=',True)]</field>
     </record>
 
+    <record model="ir.ui.view" id="email_template_loan_confirm_paid_extension">
+        <field name="name">email.template.form</field>
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="easy_my_coop_loan.email_template_loan_confirm_paid"/>
+        <field name="arch" type="xml">
+            <field name="email_from" position="before">
+                <field name="template_key">loan_payment_req</field>
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Fixing error introduced by https://github.com/coopiteasy/vertical-cooperative/pull/130 and https://github.com/coopiteasy/investor-wallet-platform/pull/63. The get_confirm_paid_email_template() function in the investor_wallet_platform_base module requires the email template to have the key template_key = 'loan_payment_received'.

Also limited the email template search to 1.