### PR TITLE
[12.0] generate template

### DIFF
--- a/investor_wallet_platform_base/__manifest__.py
+++ b/investor_wallet_platform_base/__manifest__.py
@@ -42,6 +42,7 @@
         'report/cooperator_to_certificat.xml',
         'report/easy_my_coop_report.xml',
         'report/cooperator_invoice.xml',
+        'data/cron.xml',
         'data/mail_template_data.xml'
         ],
     'demo': [

--- a/investor_wallet_platform_base/data/cron.xml
+++ b/investor_wallet_platform_base/data/cron.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2020 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="ir_cron_generate_all_missing_mail_templates" model="ir.cron">
+        <field name="name">Generate all missing mail templates</field>
+        <field name="model_id" ref="model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_generate_mail_template()</field>
+        <field name="interval_number">100</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="True"/>
+        <field name="active" eval="False"/>
+    </record>
+</odoo>

--- a/investor_wallet_platform_base/data/mail_template_data.xml
+++ b/investor_wallet_platform_base/data/mail_template_data.xml
@@ -33,7 +33,7 @@
     </data>
     <data noupdate="1">
         <record id="investor_wallet_platform_base.email_template_release_capital" model="mail.template">
-        	<field name="name">Request to Release Capital - Send by Email</field>
+        	<field name="name">Request to Release Capital - Send by Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">${object.structure.name} Request to Release Capital (Ref ${object.number or 'n/a'})</field>
             <field name="partner_to">${object.partner_id.id}</field>
@@ -82,7 +82,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_confirmation" model="mail.template">
-            <field name="name">Confirmation Email</field>
+            <field name="name">Confirmation Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">Subscription request confirmation</field>
             <field name="email_to">${object.email}</field>
@@ -131,7 +131,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_confirmation_company" model="mail.template">
-            <field name="name">Company Confirmation Email</field>
+            <field name="name">Company Confirmation Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">Subscription request confirmation</field>
             <field name="email_to">${object.email},${object.company_email}</field>
@@ -182,7 +182,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_certificat" model="mail.template">
-            <field name="name"> Confirmation - Send By Email</field>
+            <field name="name"> Confirmation - Send By Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject"> Confirmation</field>
             <field name="partner_to">${object.partner_id.id}</field>
@@ -233,7 +233,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_certificat_increase" model="mail.template">
-            <field name="name">Share Increase -  Confirmation - Send By Email</field>
+            <field name="name">Share Increase -  Confirmation - Send By Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">Payment Received Confirmation</field>
             <field name="partner_to">${object.partner_id.id}</field>
@@ -284,7 +284,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_share_transfer" model="mail.template">
-            <field name="name">Share transfer - Send By Email</field>
+            <field name="name">Share transfer - Send By Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">Share transfert</field>
             <field name="partner_to">${object.partner_id_to.id}</field>
@@ -335,7 +335,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.email_template_share_update" model="mail.template">
-            <field name="name">Share update - Send By Email</field>
+            <field name="name">Share update - Send By Email - Template</field>
             <field name="email_from">${(object.structure.email or object.user_id.email)|safe}</field>
             <field name="subject">Share update</field>
             <field name="partner_to">${object.partner_id.id}</field>
@@ -386,7 +386,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.loan_subscription_confirmation" model="mail.template">
-            <field name="name">Loan Subscription Confirmation Email</field>
+            <field name="name">Loan Subscription Confirmation Email - Template</field>
             <field name="email_from">${(object.structure.email or object.loan_issue_id.user_id.email)|safe}</field>
             <field name="subject">${object.structure.name} Loan subscription confirmation (Ref ${object.loan_issue_id.name or 'n/a'})</field>
             <field name="email_to">${object.partner_id.email}</field>
@@ -435,7 +435,7 @@
         </record>
 
         <record id="investor_wallet_platform_base.loan_issue_payment_request" model="mail.template">
-            <field name="name">Loan Issue Payment Request - Send by Email</field>
+            <field name="name">Loan Issue Payment Request - Send by Email - Template</field>
             <field name="email_from">${(object.structure.email or object.loan_issue_id.user_id.email)|safe}</field>
             <field name="subject">${object.structure.name} Payment request (Ref ${object.loan_issue_id.name or 'n/a'})</field>
             <field name="partner_to">${object.partner_id.id}</field>
@@ -484,7 +484,7 @@
         </record>
 
         <record id="email_template_notification" model="mail.template">
-            <field name="name">Subscription Notification Email</field>
+            <field name="name">Subscription Notification Email - Template</field>
             <field name="email_from">${object.company_id.email|safe}</field>
             <field name="subject">New subscription notification</field>
             <field name="email_to">${object.structure.email}</field>
@@ -539,7 +539,7 @@
         </record>
 
         <record id="email_template_notification_company" model="mail.template">
-            <field name="name">Company Subscription Notification Email</field>
+            <field name="name">Company Subscription Notification Email - Template</field>
             <field name="email_from">${object.company_id.email|safe}</field>
             <field name="subject">New subscription notification</field>
             <field name="email_to">${object.structure.email}</field>

--- a/investor_wallet_platform_base/models/mail_template.py
+++ b/investor_wallet_platform_base/models/mail_template.py
@@ -34,13 +34,13 @@ class MailTemplate(models.Model):
                                readonly=True)
     iwp = fields.Boolean(string="IWP mail template")
 
-    def get_email_template_by_key(self, mail_template_key, structure):
+    def get_email_template_by_key(self, mail_template_key, structure, raise_=True):
         template_obj = self.env['mail.template']
         mail_template = template_obj.search([
                             ('template_key', '=', mail_template_key),
                             ('structure', '=', structure.id)], limit=1)
 
-        if not mail_template:
+        if not mail_template and raise_:
             raise ValidationError(
                 _("Please generate emails for your structure.")
             )

--- a/investor_wallet_platform_base/models/partner.py
+++ b/investor_wallet_platform_base/models/partner.py
@@ -5,6 +5,9 @@
 from odoo import api, fields, models, _
 
 from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
+import logging
+_logger = logging.getLogger(__name__)
 
 
 class ResPartner(models.Model):
@@ -373,7 +376,21 @@ class ResPartner(models.Model):
                     name = "%s - %s" % (mail_template.name, self.name)
                     struct_mail_template.name = name
         else:
-            raise UserError(_('You need first to define a mail server out'))
+            raise ValidationError(
+                _(
+                    'You need first to define a mail server out for %s'
+                ) % self.name
+            )
+
+    @api.model
+    def cron_generate_mail_template(self):
+        structures = self.search([("is_platform_structure", "=", True)])
+        for structure in structures:
+            try:
+                structure.generate_mail_templates()
+            except ValidationError as e:
+                _logger.error(e.name)
+
 
     @api.multi
     def validation_request(self):

--- a/investor_wallet_platform_base/models/partner.py
+++ b/investor_wallet_platform_base/models/partner.py
@@ -357,17 +357,21 @@ class ResPartner(models.Model):
     def generate_mail_templates(self):
         self.ensure_one()
         if self.mail_serveur_out:
-            mail_templ = self.env['mail.template']._get_email_template_dict()
+            mail_templates = self.env['mail.template']._get_email_template_dict()
+            generated_template_keys = self.mail_template_ids.mapped(
+                'template_key'
+            )
 
-            if not self.mail_template_ids:
-                for mt_key, mt_xml_id in mail_templ.items():
+            for mt_key, mt_xml_id in mail_templates.items():
+                if mt_key not in generated_template_keys:
                     mail_template = self.env.ref(mt_xml_id, False)
                     struct_mail_template = mail_template.copy(default={
                         'mail_server_id': self.mail_serveur_out.id,
                         'structure': self.id,
                         'template_key': mt_key
                     })
-                    struct_mail_template.name = mail_template.name
+                    name = "%s - %s" % (mail_template.name, self.name)
+                    struct_mail_template.name = name
         else:
             raise UserError(_('You need first to define a mail server out'))
 

--- a/investor_wallet_platform_base/views/mail_template.xml
+++ b/investor_wallet_platform_base/views/mail_template.xml
@@ -21,8 +21,10 @@
         <field name="model">mail.template</field>
         <field name="inherit_id" ref="mail.email_template_form"/>
         <field name="arch" type="xml">
-            <field name="model_id" position="before">
+            <field name="model_id" position="after">
                 <field name="structure" groups="investor_wallet_platform_base.group_platform_wallet_user" />
+                <field name="template_key" groups="investor_wallet_platform_base.group_platform_wallet_user" />
+                <field name="iwp" groups="investor_wallet_platform_base.group_platform_wallet_user" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
- change name of iwp mail templates to distinguish from emc (but they are in noupdate _donc bon_)
-`generate_mail_templates` generates missing templates for structure based on key list
- unactive cron generates templates for all structures (w/o erasing existing ones). Skips over misconfigured structures.
- add technical fields for platform managers.