### PR TITLE
[IMP] iwp: book_value becomes book_value_txt

### DIFF
--- a/investor_wallet_platform_base/models/product_template.py
+++ b/investor_wallet_platform_base/models/product_template.py
@@ -26,7 +26,8 @@ class ProductTemplate(models.Model):
         [("yes", "Yes"), ("no", "No")], string="Solidary product"
     )
     banking = fields.Selection([("yes", "Yes"), ("no", "No")], string="Banking product")
-    book_value = fields.Float(string="Book value", translate=True)
+    # txt_suffix in case we need Float in the future
+    book_value_txt = fields.Char(string="Book value", translate=True)
     dividend_policy = fields.Html(string="Dividend policy", translate=True)
     voting_rights = fields.Html(
         string="Voting rights",

--- a/investor_wallet_platform_base/views/loan_issue_view.xml
+++ b/investor_wallet_platform_base/views/loan_issue_view.xml
@@ -57,11 +57,7 @@
                             <field name="fees" />
                         </group>
                         <group>
-                            <field
-                                name="book_value"
-                                widget='monetary'
-                                options="{'currency_field': 'currency_id', 'field_digits': True}"
-                            />
+                            <field name="book_value" />
                             <field name="info_note_url" />
                             <field name="advantages" />
                             <field name="oversubscription_policy" />

--- a/investor_wallet_platform_base/views/product_view.xml
+++ b/investor_wallet_platform_base/views/product_view.xml
@@ -46,7 +46,7 @@
                     <group attrs="{'invisible': [('is_share','=',False)]}">
                         <group>
                             <field name="lst_price" readonly="True" />
-                            <field name="book_value" readonly="True" />
+                            <field name="book_value_txt" readonly="True" />
                             <field name="subscription_start_text" readonly="True" />
                             <field name="subscription_end_text" readonly="True" />
                             <field name="subscription_length" readonly="True" />
@@ -71,11 +71,7 @@
                     options="{'currency_field': 'currency_id', 'field_digits': True}"
                     attrs="{'readonly': [('product_variant_count', '&gt;', 1)]}"
                 />
-                    <field
-                    name="book_value"
-                    widget='monetary'
-                    options="{'currency_field': 'currency_id', 'field_digits': True}"
-                />
+                    <field name="book_value_txt" />
                 </field>
                 <field name="short_name" position="after">
                     <field name="default_code" />


### PR DESCRIPTION
# [TASK](https://gestion.coopiteasy.be/web#id=6188&view_type=form&model=project.task&action=475&active_id=198)

- changed type and name of product field `book_value` to `book_value_txt`
- also removed the monetary widget of the loan issue field `book_value` which is not a float anymore